### PR TITLE
Added instructions for including in Android Studio 2.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ content.
 
 ### Adding the library as a project dependency ###
 
-For [Android Studio](http://developer.android.com/sdk/installing/studio.html) (which is based on 
+For [Android Studio](http://developer.android.com/sdk/installing/studio.html) 2.2, simply use Help, then type "import module", and use the wizzard.
+
+For older versions of [Android Studio](http://developer.android.com/sdk/installing/studio.html) (which is based on 
 [Intellij IDEA](http://www.jetbrains.com/idea/)) this consists of the following steps (at the
 time of writing anyway):
 


### PR DESCRIPTION
The instructions to include TiledBitmapView don't apply to new versions of Android Studio. A small edit to README.md remedies this, while retaining the original instructions.